### PR TITLE
get_abis: run in bash

### DIFF
--- a/truffle/get_abis.sh
+++ b/truffle/get_abis.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
Because /bin/sh can't function

Signed-off-by: Daniel Zvara <dan.zvara@gmail.com>