### PR TITLE
Contract: New contract for caching blockchain

### DIFF
--- a/truffle/contracts/Energy.sol
+++ b/truffle/contracts/Energy.sol
@@ -7,14 +7,14 @@ contract Energy {
     uint public offeredAmount;
     mapping (address => uint) public remainingEnergy;
     address public seller;
-    address public master_addr;
+
+    event finalUpdate(uint blockNumber);
+    event update(uint blockNumber);
 
     function Energy(address seller_, uint unitPrice_, uint offeredAmount_) public {
         unitPrice = unitPrice_;
         offeredAmount = offeredAmount_;
         seller = seller_;
-        // Sender is master contract, this is called in sell function
-        master_addr = msg.sender;
     }
 
     function buy(uint amount) public {
@@ -22,8 +22,9 @@ contract Energy {
         offeredAmount -= amount;
         remainingEnergy[msg.sender] += amount;
         if (offeredAmount == 0) {
-            Master master = Master(master_addr);
-            master.deregister(this);
+            finalUpdate(block.number);
+        } else {
+            update(block.number);
         }
     }
 

--- a/truffle/contracts/Energy.sol
+++ b/truffle/contracts/Energy.sol
@@ -7,6 +7,7 @@ contract Energy {
     uint public offeredAmount;
     mapping (address => uint) public remainingEnergy;
     address public seller;
+    bool public noUpdate;
 
     event finalUpdate(uint blockNumber);
     event update(uint blockNumber);
@@ -15,6 +16,7 @@ contract Energy {
         unitPrice = unitPrice_;
         offeredAmount = offeredAmount_;
         seller = seller_;
+        noUpdate = false;
     }
 
     function buy(uint amount) public {
@@ -22,6 +24,7 @@ contract Energy {
         offeredAmount -= amount;
         remainingEnergy[msg.sender] += amount;
         if (offeredAmount == 0) {
+            noUpdate = true;
             finalUpdate(block.number);
         } else {
             update(block.number);

--- a/truffle/contracts/Energy.sol
+++ b/truffle/contracts/Energy.sol
@@ -6,16 +6,17 @@ contract Energy {
     uint public unitPrice;
     uint public offeredAmount;
     mapping (address => uint) public remainingEnergy;
+    uint public boughtAmount;  // sum of remainingEnergy;
     address public seller;
     bool public noUpdate;
 
-    event finalUpdate(uint blockNumber);
     event update(uint blockNumber);
 
     function Energy(address seller_, uint unitPrice_, uint offeredAmount_) public {
         unitPrice = unitPrice_;
         offeredAmount = offeredAmount_;
         seller = seller_;
+        boughtAmount = 0;
         noUpdate = false;
     }
 
@@ -23,12 +24,9 @@ contract Energy {
         require(amount <= offeredAmount);
         offeredAmount -= amount;
         remainingEnergy[msg.sender] += amount;
-        if (offeredAmount == 0) {
-            noUpdate = true;
-            finalUpdate(block.number);
-        } else {
-            update(block.number);
-        }
+        boughtAmount += amount;
+        update(block.number);
+        // there will always be an update when the buyer consumes energy
     }
 
     function consume(uint amount) public payable {
@@ -36,6 +34,11 @@ contract Energy {
         require(msg.value >= unitPrice * amount);
         seller.transfer(msg.value);
         remainingEnergy[msg.sender] -= amount;
+        boughtAmount -= amount;
+        if (boughtAmount == 0 && offeredAmount == 0) {
+            noUpdate = true;
+        }
+        update(block.number);
     }
 
 }

--- a/truffle/contracts/Energy.sol
+++ b/truffle/contracts/Energy.sol
@@ -10,7 +10,7 @@ contract Energy {
     address public seller;
     bool public noUpdate;
 
-    event update(uint blockNumber);
+    event Update(uint blockNumber);
 
     function Energy(address seller_, uint unitPrice_, uint offeredAmount_) public {
         unitPrice = unitPrice_;
@@ -25,7 +25,7 @@ contract Energy {
         offeredAmount -= amount;
         remainingEnergy[msg.sender] += amount;
         boughtAmount += amount;
-        update(block.number);
+        Update(block.number);
         // there will always be an update when the buyer consumes energy
     }
 
@@ -38,7 +38,8 @@ contract Energy {
         if (boughtAmount == 0 && offeredAmount == 0) {
             noUpdate = true;
         }
-        update(block.number);
+
+        Update(block.number);
     }
 
 }

--- a/truffle/contracts/Master.sol
+++ b/truffle/contracts/Master.sol
@@ -13,6 +13,7 @@ contract Master {
     // Sender is the seller, return deployed energy contract
     function sell(uint unitPrice, uint amountOffered) public returns(address) {
         // TODO: delegate call
+        require(amountOffered > 0);
         Energy energy = new Energy(msg.sender, unitPrice, amountOffered);
         contracts.push(energy);
         update(block.number);

--- a/truffle/contracts/Master.sol
+++ b/truffle/contracts/Master.sol
@@ -3,15 +3,9 @@ pragma solidity ^0.4.10;
 import "./Energy.sol";
 
 contract Master {
-    struct ContractEntity {
-        address contract_addr;
-        address seller;
-        bool deregistered;
-    }
 
-    ContractEntity[] public contracts;
-    // lookup index of contract in the list
-    mapping (address => uint) lookupIdxByContract;
+    address[] public contracts;
+    event update(uint blockNumber);
 
     function Master() public {
     }
@@ -20,18 +14,9 @@ contract Master {
     function sell(uint unitPrice, uint amountOffered) public returns(address) {
         // TODO: delegate call
         Energy energy = new Energy(msg.sender, unitPrice, amountOffered);
-        ContractEntity memory entity;
-        entity.contract_addr = energy;
-        entity.seller = msg.sender;
-        lookupIdxByContract[energy] = contracts.length;
-        contracts.push(entity);
+        contracts.push(energy);
+        update(block.number);
         return energy;
-    }
-
-    // Called by energy contract for deregister
-    function deregister(address contract_addr) public {
-        require(msg.sender == contract_addr);
-        contracts[lookupIdxByContract[contract_addr]].deregistered = true;
     }
 
     function contractCount() view public returns(uint) {

--- a/truffle/contracts/Master.sol
+++ b/truffle/contracts/Master.sol
@@ -5,7 +5,7 @@ import "./Energy.sol";
 contract Master {
 
     address[] public contracts;
-    event update(uint blockNumber);
+    event Update(uint index);
 
     function Master() public {
     }
@@ -16,7 +16,7 @@ contract Master {
         require(amountOffered > 0);
         Energy energy = new Energy(msg.sender, unitPrice, amountOffered);
         contracts.push(energy);
-        update(block.number);
+        Update(contracts.length - 1);
         return energy;
     }
 

--- a/truffle/test/TestMaster.sol
+++ b/truffle/test/TestMaster.sol
@@ -15,10 +15,8 @@ contract TestMaster {
         uint actual_price = energy.unitPrice();
         uint actual_offeredAmount = energy.offeredAmount();
         address actual_seller = energy.seller();
-        address actual_master_addr = energy.master_addr();
         Assert.equal(price, actual_price, "Price should be set");
         Assert.equal(offeredAmount, actual_offeredAmount, "offeredAmount should be set");
         Assert.equal(this, actual_seller, "Seller should be caller");
-        Assert.equal(master, actual_master_addr, "Master address should be set");
     }
 }


### PR DESCRIPTION
Abstract: We try to modify contract in order to cache the blockchain for more efficient access. This is first step.

We sync all contracts initially and subscribe events from both Master contract and Energy contract. We wait for events to fire so that we don't need to sync the blockchain again every time.

The amount of work of doing this is non-trivial. Let's work on a cache-blockchain branch, but before that, I would like to use PRs to make sure that small changes are reviewed first before we continue.

The first PR is on modification of the contract. Upon that we can reorganise codes in dapp and meter client accordingly. Please review.

