### PR TITLE
dapp: Add pagination, number of entries dropdown and filtering to table

### DIFF
--- a/dapp/package-lock.json
+++ b/dapp/package-lock.json
@@ -1020,6 +1020,11 @@
         "lazy-cache": "1.0.4"
       }
     },
+    "chain-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.0.tgz",
+      "integrity": "sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w="
+    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -1254,6 +1259,99 @@
         "es5-ext": "0.10.35"
       }
     },
+    "d3-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.1.tgz",
+      "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw=="
+    },
+    "d3-collection": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.4.tgz",
+      "integrity": "sha1-NC39EoN8kJdPM/HMCnha6lcNzcI="
+    },
+    "d3-color": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.0.3.tgz",
+      "integrity": "sha1-vHZD/KjlOoNH4vva/6I2eWtYUJs="
+    },
+    "d3-format": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.2.1.tgz",
+      "integrity": "sha512-U4zRVLDXW61bmqoo+OJ/V687e1T5nVd3TAKAJKgtpZ/P1JsMgyod0y9br+mlQOryTAACdiXI3wCjuERHFNp91w=="
+    },
+    "d3-interpolate": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
+      "integrity": "sha512-mOnv5a+pZzkNIHtw/V6I+w9Lqm9L5bG3OTXPM5A+QO0yyVMQ4W1uZhR+VOJmazaOZXri2ppbiZ5BUNWT0pFM9A==",
+      "requires": {
+        "d3-color": "1.0.3"
+      }
+    },
+    "d3-path": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.5.tgz",
+      "integrity": "sha1-JB6xhJvZ6egCHA0KeZ+KDo5EF2Q="
+    },
+    "d3-scale": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.6.tgz",
+      "integrity": "sha1-vOGdqA06DPQiyVQ64zIghiILNO0=",
+      "requires": {
+        "d3-array": "1.2.1",
+        "d3-collection": "1.0.4",
+        "d3-color": "1.0.3",
+        "d3-format": "1.2.1",
+        "d3-interpolate": "1.1.6",
+        "d3-time": "1.0.8",
+        "d3-time-format": "2.1.1"
+      }
+    },
+    "d3-shape": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.2.0.tgz",
+      "integrity": "sha1-RdAVOPBkuv0F6j1tLLdI/YxB93c=",
+      "requires": {
+        "d3-path": "1.0.5"
+      }
+    },
+    "d3-time": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.8.tgz",
+      "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ=="
+    },
+    "d3-time-format": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.1.tgz",
+      "integrity": "sha512-8kAkymq2WMfzW7e+s/IUNAtN/y3gZXGRrdGfo6R8NKPAA85UBTxZg5E61bR6nLwjPjj4d3zywSQe1CkYLPFyrw==",
+      "requires": {
+        "d3-time": "1.0.8"
+      }
+    },
+    "datatables": {
+      "version": "1.10.13",
+      "resolved": "https://registry.npmjs.org/datatables/-/datatables-1.10.13.tgz",
+      "integrity": "sha1-m7Lexvfc8CBJoA5PDn0/4AnDk0Y=",
+      "requires": {
+        "jquery": "3.2.1"
+      }
+    },
+    "datatables.net": {
+      "version": "1.10.16",
+      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.16.tgz",
+      "integrity": "sha1-SwUtEIKCQmG2ju2dInQbcR09JGk=",
+      "requires": {
+        "jquery": "3.2.1"
+      }
+    },
+    "datatables.net-bs": {
+      "version": "1.10.16",
+      "resolved": "https://registry.npmjs.org/datatables.net-bs/-/datatables.net-bs-1.10.16.tgz",
+      "integrity": "sha1-sIVPWzdPcTrj20FWx86op2DD3nY=",
+      "requires": {
+        "datatables.net": "1.10.16",
+        "jquery": "3.2.1"
+      }
+    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
@@ -1374,6 +1472,11 @@
       "requires": {
         "buffer-indexof": "1.1.1"
       }
+    },
+    "dom-helpers": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.2.1.tgz",
+      "integrity": "sha1-MgPgf+0he9H0JLAZc1WC/Deyglo="
     },
     "domain-browser": {
       "version": "1.1.7",
@@ -3373,6 +3476,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+    },
+    "math-expression-evaluator": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
+      "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw="
     },
     "md5.js": {
       "version": "1.3.4",
@@ -7427,6 +7535,11 @@
         "sha.js": "2.4.9"
       }
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -7564,6 +7677,14 @@
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
       "integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw="
     },
+    "raf": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.0.tgz",
+      "integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
+      "requires": {
+        "performance-now": "2.1.0"
+      }
+    },
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
@@ -7647,6 +7768,14 @@
         "prop-types": "15.6.0"
       }
     },
+    "react-resize-detector": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-1.1.0.tgz",
+      "integrity": "sha512-68KVcQlhcWQGXMAie82YueCa4f4yqwEoiQbVyYlSgJEin1zMtNBLLeU/+6FLNf1TTgjwSfpbMTJTw/uU0HNgtQ==",
+      "requires": {
+        "prop-types": "15.6.0"
+      }
+    },
     "react-router": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.2.0.tgz",
@@ -7686,6 +7815,30 @@
         "loose-envify": "1.3.1",
         "prop-types": "15.6.0",
         "react-router": "4.2.0",
+        "warning": "3.0.0"
+      }
+    },
+    "react-smooth": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-1.0.0.tgz",
+      "integrity": "sha1-sp2+vd3bBtIbWwiWIWf7nqwYl9g=",
+      "requires": {
+        "lodash": "4.17.4",
+        "prop-types": "15.6.0",
+        "raf": "3.4.0",
+        "react-transition-group": "2.2.1"
+      }
+    },
+    "react-transition-group": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.2.1.tgz",
+      "integrity": "sha512-q54UBM22bs/CekG8r3+vi9TugSqh0t7qcEVycaRc9M0p0aCEu+h6rp/RFiW7fHfgd1IKpd9oILFTl5QK+FpiPA==",
+      "requires": {
+        "chain-function": "1.0.0",
+        "classnames": "2.2.5",
+        "dom-helpers": "3.2.1",
+        "loose-envify": "1.3.1",
+        "prop-types": "15.6.0",
         "warning": "3.0.0"
       }
     },
@@ -7733,6 +7886,29 @@
         "set-immediate-shim": "1.0.1"
       }
     },
+    "recharts": {
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-1.0.0-beta.5.tgz",
+      "integrity": "sha1-Wxj58PPQRJWlZXHoSJzUOeHfX+4=",
+      "requires": {
+        "classnames": "2.2.5",
+        "core-js": "2.5.1",
+        "d3-interpolate": "1.1.6",
+        "d3-scale": "1.0.6",
+        "d3-shape": "1.2.0",
+        "lodash": "4.17.4",
+        "prop-types": "15.6.0",
+        "react-resize-detector": "1.1.0",
+        "react-smooth": "1.0.0",
+        "recharts-scale": "0.3.2",
+        "reduce-css-calc": "1.3.0"
+      }
+    },
+    "recharts-scale": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.3.2.tgz",
+      "integrity": "sha1-2sdiFxSkdl0VLLKtvDDHO4MSCMk="
+    },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -7740,6 +7916,38 @@
       "requires": {
         "indent-string": "2.1.0",
         "strip-indent": "1.0.1"
+      }
+    },
+    "reduce-css-calc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+      "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
+      "requires": {
+        "balanced-match": "0.4.2",
+        "math-expression-evaluator": "1.2.17",
+        "reduce-function-call": "1.0.2"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+        }
+      }
+    },
+    "reduce-function-call": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
+      "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
+      "requires": {
+        "balanced-match": "0.4.2"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+        }
       }
     },
     "regenerate": {

--- a/dapp/package.json
+++ b/dapp/package.json
@@ -6,8 +6,11 @@
   "dependencies": {
     "babel-core": "^6.26.0",
     "bignumber.js": "^4.1.0",
+    "datatables.net": "^1.10.16",
+    "datatables.net-bs": "^1.10.16",
     "dateformat": "^3.0.2",
     "immutability-helper": "^2.4.0",
+    "jquery": "^3.2.1",
     "oo7": "^0.5.8",
     "oo7-parity": "^0.6.13",
     "oo7-react": "^0.4.8",
@@ -15,7 +18,7 @@
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-router-dom": "^4.2.2",
-    "recharts": "^1.0.0-beta.1",
+    "recharts": "^1.0.0-beta.5",
     "webpack": "^3.8.1",
     "webpack-dev-server": "^2.9.3"
   },

--- a/dapp/src/client/scripts/app.jsx
+++ b/dapp/src/client/scripts/app.jsx
@@ -20,7 +20,7 @@ export class App extends React.Component {
     super();
     this.master = makeMasterContract();
     this.state = {
-      contracts: [],
+      contracts: {},
       mySellerContracts: [],
       myBuyerContracts: [],
       sellTx: null,
@@ -125,17 +125,13 @@ export class App extends React.Component {
   getAvailableContracts() {
     this.getContracts("/contract/available_contracts")
       .then(data => {
-        const contracts = {}
-        for (let c in data) {
-          const contract = data[c];
-          contracts[contract.address] = contract;
-          contracts[contract.address].tx = null;
-        }
+        data.forEach(contract => contract.tx = null)
+
         this.setState({
-          contracts: contracts,
+          contracts: data,
         });
 
-        this.updateHistogram();
+        //this.updateHistogram();
       });
   }
 
@@ -152,9 +148,16 @@ export class App extends React.Component {
 
   buyEnergy(contractAddress) {
     const contract = makeContract(contractAddress);
+    var index = 0;
+    for (var i = 0; i < this.state.contracts.length; i++) {
+      if (this.state.contracts[i].address == contractAddress) {
+        index = i;
+        break;
+      }
+    }
     this.setState(update(this.state, {
       contracts: {
-        [contractAddress]: {
+        [index]: {
           tx: {
             $set: contract.buy(this.buyAmountBond)
           }

--- a/dapp/src/client/scripts/app.jsx
+++ b/dapp/src/client/scripts/app.jsx
@@ -131,7 +131,7 @@ export class App extends React.Component {
           contracts: data,
         });
 
-        //this.updateHistogram();
+        this.updateHistogram();
       });
   }
 

--- a/dapp/src/client/scripts/availableContractsTable.jsx
+++ b/dapp/src/client/scripts/availableContractsTable.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {BButton, InputBond, TransactionProgressLabel} from 'parity-reactive-ui'
+
+const $ = require('jquery');
+$.DataTable = require('datatables.net-bs');
+
+export class AvailableContractsTable extends React.Component {
+
+  componentDidMount() {
+    const columns =
+
+    $(this.refs.table).DataTable({
+       "dom":
+         "<'data-table-wrapper'" +
+         "<'row'<'col-sm-6'l><'col-sm-6'>>" +
+         "<'row'<'col-sm-12'tr>>" +
+         "<'row'<'col-sm-5'i><'col-sm-7'p>>" +
+         ">",
+       "data": this.props.contracts,
+       "columns": [
+         {
+           title: "Amount Offered",
+           width: 100,
+           data: "offeredAmount",
+           render: (data, type, row) => data + " kWh/day"
+         },
+         {
+           title: "Amount Available",
+           width: 100,
+           data: "remainingAmount",
+           render: (data, type, row) => data + " kWh/day"
+         },
+         {
+            title: "Price",
+            width: 100,
+            data: "unitPrice",
+            render: (data, type, row) => data + " £/kWh"
+         },
+         {
+            title: "Buy Energy",
+            width: 400,
+            data: null,
+            createdCell: (cell, cellData, rowData, rowIndex, colIndex) => ReactDOM.render(
+              <form role="form">
+                <InputBond placeholder="kWh/day" bond={this.props.amountBond} style={{width: "100%"}} action>
+                  <input />
+                  {rowData.tx === null
+                    ? <BButton className="btn btn-primary" content="Buy Energy" onClick={() => this.props.buyEnergy(rowData.address)}/>
+                    : <TransactionProgressLabel value={rowData.tx}/>
+                  }
+                </InputBond>
+              </form>, cell)
+         },
+       ],
+       "order": [[2, "asc"]],
+    })
+  }
+
+  componentWillUnmount() {
+    $('.data-table-wrapper')
+    .find('table')
+    .DataTable()
+    .destroy(true)
+  }
+
+  shouldComponentUpdate(nextProps) {
+    const table = $('.data-table-wrapper')
+    .find('table')
+    .DataTable();
+    table.clear();
+    console.log(nextProps.contracts)
+    table.rows.add(nextProps.contracts);
+    table.draw();
+    return false;
+  }
+
+  render() {
+    return (
+      <div>
+        <table width="100%" className="table table-striped table-bordered table-hover" ref="table" />
+      </div>
+    )
+  }
+ }

--- a/dapp/src/client/scripts/availableContractsTable.jsx
+++ b/dapp/src/client/scripts/availableContractsTable.jsx
@@ -26,7 +26,7 @@ export class AvailableContractsTable extends React.Component {
            render: (data, type, row) => data + " kWh/day"
          },
          {
-           title: "Amount Available",
+           title: "Amount Bought",
            width: 100,
            data: "remainingAmount",
            render: (data, type, row) => data + " kWh/day"

--- a/dapp/src/client/scripts/availableContractsTable.jsx
+++ b/dapp/src/client/scripts/availableContractsTable.jsx
@@ -69,7 +69,6 @@ export class AvailableContractsTable extends React.Component {
     .find('table')
     .DataTable();
     table.clear();
-    console.log(nextProps.contracts)
     table.rows.add(nextProps.contracts);
     table.draw();
     return false;

--- a/dapp/src/client/scripts/availableContractsTable.jsx
+++ b/dapp/src/client/scripts/availableContractsTable.jsx
@@ -41,6 +41,7 @@ export class AvailableContractsTable extends React.Component {
             title: "Buy Energy",
             width: 400,
             data: null,
+            orderable: false,
             createdCell: (cell, cellData, rowData, rowIndex, colIndex) => ReactDOM.render(
               <form role="form">
                 <InputBond placeholder="kWh/day" bond={this.props.amountBond} style={{width: "100%"}} action>

--- a/dapp/src/client/scripts/buyEnergyPanel.jsx
+++ b/dapp/src/client/scripts/buyEnergyPanel.jsx
@@ -4,29 +4,6 @@ import {AvailableContractsTable} from './availableContractsTable'
 
 export class BuyEnergyPanel extends React.Component {
   render() {
-    var tableBody = Object.keys(this.props.contracts).map(address => {
-      const contract = this.props.contracts[address];
-      return (
-        <tr key={contract.address}>
-          <td>Some date</td>
-          <td>{contract.offeredAmount}
-            kWh/day</td>
-          <td>£{contract.unitPrice}/kWh</td>
-          <td>
-            <form role="form">
-              <InputBond placeholder="kWh/day" bond={this.props.amountBond} style={{width: "100%"}} action>
-                <input />
-                {contract.tx === null
-                  ? <BButton className="btn btn-primary" content="Buy Energy" onClick={() => this.props.buyEnergy(address)}/>
-                  : <TransactionProgressLabel value={contract.tx}/>
-                }
-              </InputBond>
-            </form>
-          </td>
-        </tr>
-      );
-    });
-
     return (<div className="panel panel-default">
       <div className="panel-heading">
         <i className="fa fa-bar-chart-o fa-fw"></i>
@@ -36,7 +13,6 @@ export class BuyEnergyPanel extends React.Component {
       <div className="panel-body">
         <AvailableContractsTable contracts={this.props.contracts} amountBond={this.props.amountBond} buyEnergy={this.props.buyEnergy}/>
       </div>
-      {/* /.panel-body */}
     </div>)
   }
 }

--- a/dapp/src/client/scripts/buyEnergyPanel.jsx
+++ b/dapp/src/client/scripts/buyEnergyPanel.jsx
@@ -1,12 +1,8 @@
 import React from 'react';
 import {BButton, InputBond, TransactionProgressLabel} from 'parity-reactive-ui'
+import {AvailableContractsTable} from './availableContractsTable'
 
 export class BuyEnergyPanel extends React.Component {
-
-  constructor(props) {
-    super(props);
-  }
-
   render() {
     var tableBody = Object.keys(this.props.contracts).map(address => {
       const contract = this.props.contracts[address];
@@ -38,19 +34,7 @@ export class BuyEnergyPanel extends React.Component {
       </div>
 
       <div className="panel-body">
-        <table width="100%" className="table table-striped table-bordered table-hover">
-          <thead>
-            <tr>
-              <th>Date offered</th>
-              <th>Amount available</th>
-              <th>Price</th>
-              <th>Buy</th>
-            </tr>
-          </thead>
-          <tbody>
-            {tableBody}
-          </tbody>
-        </table>
+        <AvailableContractsTable contracts={this.props.contracts} amountBond={this.props.amountBond} buyEnergy={this.props.buyEnergy}/>
       </div>
       {/* /.panel-body */}
     </div>)


### PR DESCRIPTION
The available contracts table is now much more sophisticated and allows for pagination, filtering and choosing the number of entries to display (using a DataTables plugin), all on the front-end ofc.